### PR TITLE
Support multiple connections by specifying a handler

### DIFF
--- a/src/HijelHID_BLEKeyboard.cpp
+++ b/src/HijelHID_BLEKeyboard.cpp
@@ -196,11 +196,11 @@ void HijelHID_Internal::KBServerCallbacks::onConnect(NimBLEServer* pServer, NimB
 
 void HijelHID_Internal::KBServerCallbacks::onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason) {
     (void)reason;
-    _parent->_onDisconnect();
+    _parent->_onDisconnect(connInfo.getConnHandle());
 }
 
 void HijelHID_Internal::KBServerCallbacks::onAuthenticationComplete(NimBLEConnInfo& connInfo) {
-    _parent->_onAuthComplete(connInfo.isEncrypted());
+    _parent->_onAuthComplete(connInfo.getConnHandle(), connInfo.isEncrypted());
 }
 
 void HijelHID_Internal::KBServerCallbacks::onConfirmPassKey(NimBLEConnInfo& connInfo, uint32_t pass_key) {
@@ -1094,13 +1094,23 @@ void HijelHID_BLEKeyboard::afterWake() {
 }
 
 void HijelHID_BLEKeyboard::_onConnect(uint16_t connHandle) {
+    if (_authenticated && _connHandle != connHandle) {
+        _logNf("Secondary client connected (handle=0x%04X).", connHandle);
+        return;
+    }
+
     _connected  = true;
     _connHandle = connHandle;
     _connState  = _ConnState::Connecting;
     _logNf("Host connected (handle=0x%04X).", connHandle);
 }
 
-void HijelHID_BLEKeyboard::_onDisconnect() {
+void HijelHID_BLEKeyboard::_onDisconnect(uint16_t connHandle) {
+    if (_connHandle != BLE_HS_CONN_HANDLE_NONE && _connHandle != connHandle) {
+        _logNf("Secondary client disconnected (handle=0x%04X).", connHandle);
+        return;
+    }
+
     _stopIdleTimer();
     _pendingIdleTransition = false;
     _connState  = _ConnState::Disconnected;
@@ -1122,9 +1132,11 @@ void HijelHID_BLEKeyboard::_onDisconnect() {
     }
 }
 
-void HijelHID_BLEKeyboard::_onAuthComplete(bool success) {
+void HijelHID_BLEKeyboard::_onAuthComplete(uint16_t connHandle, bool success) {
     if (success) {
+        _connected     = true;
         _authenticated = true;
+        _connHandle    = connHandle;
         _connState     = _ConnState::Active;
         _logN("Pairing complete (encrypted). Requesting full-rate connection params...");
         // Request Active-state connection params: full rate, no latency.

--- a/src/HijelHID_BLEKeyboard.h
+++ b/src/HijelHID_BLEKeyboard.h
@@ -546,8 +546,8 @@ public:
 
     // ─── Internal Callbacks (do not call directly) ────────────────────────
     void        _onConnect(uint16_t connHandle);
-    void        _onDisconnect();
-    void        _onAuthComplete(bool success);
+    void        _onDisconnect(uint16_t connHandle);
+    void        _onAuthComplete(uint16_t connHandle, bool success);
     void        _onConfirmPassKey(uint32_t passkey);
     void        _onLEDWrite(uint8_t ledByte);
     static void _idleTimerCallback(TimerHandle_t xTimer);


### PR DESCRIPTION
Update the Hijel HID library so non-HID BLE clients do not break the active HID host connection.

- Pass the NimBLE connection handle through internal server callbacks.
- Track the authenticated HID host separately from secondary clients.
- Ignore disconnects from non-host clients instead of treating them as host disconnects.
- Add debug logs for secondary client connect/disconnect events.

This is an internal bug fix only. It does not change the public API, but it makes the library safe to use on a shared multi-client NimBLE server.

## Why?

This library was being used on a shared NimBLE server with both a HID host and a second BLE client. Previously, a disconnect from the secondary client could clear the library’s HID connection state and stop reports from reaching the real host.